### PR TITLE
Add support for suspense option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,14 @@
   "plugins": ["react", "prettier"],
   "rules": {
     "prettier/prettier": "error",
-    "react/jsx-filename-extension": "off"
+    "react/jsx-filename-extension": "off",
+    "react/prop-types": "off"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["./example/node_modules"]
+      }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ export default () => {
 };
 ```
 
+### `useFetch` (with Suspense)
+
+```js
+import { useFetch } from 'use-fetch-hooks';
+
+const Child = () => {
+  const { data } = useFetch('https://example/api', { suspense: true });
+
+  return <div>{data}</div>;
+};
+
+const Parent = () => (
+  <React.Suspense fallback="Loading...">
+    <Child />
+  </React.Suspense>
+);
+```
+
 ### `useLazyFetch`
 
 ```js

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import Container from './Container';
 import UseFetchBasic from './useFetch/Basic';
+import UseFetchSuspense from './useFetch/Suspense';
 import UseLazyFetchBasic from './useLazyFetch/Basic';
 
 export default () => (
@@ -10,7 +12,18 @@ export default () => (
       </a>
     </h1>
 
-    <UseFetchBasic />
-    <UseLazyFetchBasic />
+    <Container title="useFetch (Basic)">
+      <UseFetchBasic />
+    </Container>
+
+    <Container title="useFetch (Suspense)">
+      <React.Suspense fallback="Loading...">
+        <UseFetchSuspense />
+      </React.Suspense>
+    </Container>
+
+    <Container title="useLazyFetch (Basic)">
+      <UseLazyFetchBasic />
+    </Container>
   </>
 );

--- a/example/src/Container.jsx
+++ b/example/src/Container.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export default ({ title, children }) => (
+  <>
+    <h2>{title}</h2>
+    {children}
+  </>
+);

--- a/example/src/useFetch/Basic.jsx
+++ b/example/src/useFetch/Basic.jsx
@@ -5,9 +5,7 @@ export default () => {
   const { data, loading, error } = useFetch('https://reqres.in/api/things/1');
 
   return (
-    <div style={{ marginBottom: 50 }}>
-      <h2>useFetch</h2>
-
+    <>
       {loading && <div>Loading...</div>}
 
       {error && <div>{error.message}</div>}
@@ -19,6 +17,6 @@ export default () => {
           {data.data.color}
         </div>
       )}
-    </div>
+    </>
   );
 };

--- a/example/src/useFetch/Suspense.jsx
+++ b/example/src/useFetch/Suspense.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useFetch } from '../../../src';
+
+export default () => {
+  const { data } = useFetch('https://reqres.in/api/things/1', {
+    suspense: true,
+  });
+
+  return (
+    <div>
+      {data.data.name}
+      {': '}
+      {data.data.color}
+    </div>
+  );
+};

--- a/example/src/useLazyFetch/Basic.jsx
+++ b/example/src/useLazyFetch/Basic.jsx
@@ -7,9 +7,7 @@ export default () => {
   );
 
   return (
-    <div style={{ marginBottom: 50 }}>
-      <h2>useLazyFetch</h2>
-
+    <>
       {loading && <div>Loading...</div>}
 
       {error && <div>{error.message}</div>}
@@ -25,6 +23,6 @@ export default () => {
       <button type="button" onClick={getData}>
         get data
       </button>
-    </div>
+    </>
   );
 };

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
+  devtool: 'source-map',
   module: {
     rules: [
       {

--- a/src/useBaseFetch.js
+++ b/src/useBaseFetch.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import axios from 'axios';
 
-export default config => {
+export default url => {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -9,7 +9,7 @@ export default config => {
   const getData = async () => {
     try {
       setLoading(true);
-      const res = await axios(config);
+      const res = await axios(url);
       setData(res.data);
       setLoading(false);
       setError('');

--- a/src/useBaseSuspenseFetch.js
+++ b/src/useBaseSuspenseFetch.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+import { unstable_createResource as createResource } from './vendor/react-cache';
+
+const Resource = createResource(async url => axios.get(url));
+
+export default url => Resource.read(url);

--- a/src/useFetch.js
+++ b/src/useFetch.js
@@ -1,12 +1,17 @@
 import { useEffect } from 'react';
 import useBaseFetch from './useBaseFetch';
+import useBaseSuspenseFetch from './useBaseSuspenseFetch';
 
-export default config => {
-  const [getData, { data, error, loading }] = useBaseFetch(config);
+export default (url, options = {}) => {
+  if (options.suspense) {
+    return useBaseSuspenseFetch(url);
+  }
+
+  const [getData, { data, error, loading }] = useBaseFetch(url, options);
 
   useEffect(() => {
     getData();
-  }, [config.url]);
+  }, [url]);
 
   return { data, error, loading };
 };

--- a/src/useLazyFetch.js
+++ b/src/useLazyFetch.js
@@ -1,7 +1,7 @@
 import useBaseFetch from './useBaseFetch';
 
-export default config => {
-  const [getData, { data, error, loading }] = useBaseFetch(config);
+export default (url, options = {}) => {
+  const [getData, { data, error, loading }] = useBaseFetch(url, options);
 
   return [getData, { data, error, loading }];
 };

--- a/src/vendor/react-cache/index.js
+++ b/src/vendor/react-cache/index.js
@@ -1,0 +1,340 @@
+/** @license React v16.6.1
+ * react-cache.development.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+var warningWithoutStack = function() {};
+
+{
+  warningWithoutStack = function(condition, format) {
+    for (
+      var _len = arguments.length,
+        args = Array(_len > 2 ? _len - 2 : 0),
+        _key = 2;
+      _key < _len;
+      _key++
+    ) {
+      args[_key - 2] = arguments[_key];
+    }
+
+    if (format === undefined) {
+      throw new Error(
+        '`warningWithoutStack(condition, format, ...args)` requires a warning ' +
+          'message argument'
+      );
+    }
+    if (args.length > 8) {
+      // Check before the condition to catch violations early.
+      throw new Error(
+        'warningWithoutStack() currently supports at most 8 arguments.'
+      );
+    }
+    if (condition) {
+      return;
+    }
+    if (typeof console !== 'undefined') {
+      var argsWithFormat = args.map(function(item) {
+        return '' + item;
+      });
+      argsWithFormat.unshift('Warning: ' + format);
+
+      // We intentionally don't use spread (or .apply) directly because it
+      // breaks IE9: https://github.com/facebook/react/issues/13610
+      Function.prototype.apply.call(console.error, console, argsWithFormat);
+    }
+    try {
+      // --- Welcome to debugging React ---
+      // This error was thrown as a convenience so that you can use this stack
+      // to find the callsite that caused this warning to fire.
+      var argIndex = 0;
+      var message =
+        'Warning: ' +
+        format.replace(/%s/g, function() {
+          return args[argIndex++];
+        });
+      throw new Error(message);
+    } catch (x) {}
+  };
+}
+
+var warningWithoutStack$1 = warningWithoutStack;
+
+function createLRU(limit) {
+  var LIMIT = limit;
+
+  // Circular, doubly-linked list
+  var first = null;
+  var size = 0;
+
+  var cleanUpIsScheduled = false;
+
+  function scheduleCleanUp() {
+    if (cleanUpIsScheduled === false && size > LIMIT) {
+      // The cache size exceeds the limit. Schedule a callback to delete the
+      // least recently used entries.
+      cleanUpIsScheduled = true;
+      scheduler.unstable_scheduleCallback(cleanUp);
+    }
+  }
+
+  function cleanUp() {
+    cleanUpIsScheduled = false;
+    deleteLeastRecentlyUsedEntries(LIMIT);
+  }
+
+  function deleteLeastRecentlyUsedEntries(targetSize) {
+    // Delete entries from the cache, starting from the end of the list.
+    if (first !== null) {
+      var resolvedFirst = first;
+      var last = resolvedFirst.previous;
+      while (size > targetSize && last !== null) {
+        var _onDelete = last.onDelete;
+        var _previous = last.previous;
+        last.onDelete = null;
+
+        // Remove from the list
+        last.previous = last.next = null;
+        if (last === first) {
+          // Reached the head of the list.
+          first = last = null;
+        } else {
+          first.previous = _previous;
+          _previous.next = first;
+          last = _previous;
+        }
+
+        size -= 1;
+
+        // Call the destroy method after removing the entry from the list. If it
+        // throws, the rest of cache will not be deleted, but it will be in a
+        // valid state.
+        _onDelete();
+      }
+    }
+  }
+
+  function add(value, onDelete) {
+    var entry = {
+      value: value,
+      onDelete: onDelete,
+      next: null,
+      previous: null,
+    };
+    if (first === null) {
+      entry.previous = entry.next = entry;
+      first = entry;
+    } else {
+      // Append to head
+      var last = first.previous;
+      last.next = entry;
+      entry.previous = last;
+
+      first.previous = entry;
+      entry.next = first;
+
+      first = entry;
+    }
+    size += 1;
+    return entry;
+  }
+
+  function update(entry, newValue) {
+    entry.value = newValue;
+  }
+
+  function access(entry) {
+    var next = entry.next;
+    if (next !== null) {
+      // Entry already cached
+      var resolvedFirst = first;
+      if (first !== entry) {
+        // Remove from current position
+        var _previous2 = entry.previous;
+        _previous2.next = next;
+        next.previous = _previous2;
+
+        // Append to head
+        var last = resolvedFirst.previous;
+        last.next = entry;
+        entry.previous = last;
+
+        resolvedFirst.previous = entry;
+        entry.next = resolvedFirst;
+
+        first = entry;
+      }
+    } else {
+      // Cannot access a deleted entry
+      // TODO: Error? Warning?
+    }
+    scheduleCleanUp();
+    return entry.value;
+  }
+
+  function setLimit(newLimit) {
+    LIMIT = newLimit;
+    scheduleCleanUp();
+  }
+
+  return {
+    add: add,
+    update: update,
+    access: access,
+    setLimit: setLimit,
+  };
+}
+
+var Pending = 0;
+var Resolved = 1;
+var Rejected = 2;
+
+var ReactCurrentDispatcher =
+  React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
+    .ReactCurrentDispatcher;
+
+function readContext(Context, observedBits) {
+  var dispatcher = ReactCurrentDispatcher.current;
+  if (dispatcher === null) {
+    throw new Error(
+      'react-cache: read and preload may only be called from within a ' +
+        "component's render. They are not supported in event handlers or " +
+        'lifecycle methods.'
+    );
+  }
+  return dispatcher.readContext(Context, observedBits);
+}
+
+function identityHashFn(input) {
+  {
+    !(
+      typeof input === 'string' ||
+      typeof input === 'number' ||
+      typeof input === 'boolean' ||
+      input === undefined ||
+      input === null
+    )
+      ? warningWithoutStack$1(
+          false,
+          'Invalid key type. Expected a string, number, symbol, or boolean, ' +
+            'but instead received: %s' +
+            '\n\nTo use non-primitive values as keys, you must pass a hash ' +
+            'function as the second argument to createResource().',
+          input
+        )
+      : void 0;
+  }
+  return input;
+}
+
+var CACHE_LIMIT = 500;
+var lru = createLRU(CACHE_LIMIT);
+
+var entries = new Map();
+
+var CacheContext = React.createContext(null);
+
+function accessResult(resource, fetch, input, key) {
+  var entriesForResource = entries.get(resource);
+  if (entriesForResource === undefined) {
+    entriesForResource = new Map();
+    entries.set(resource, entriesForResource);
+  }
+  var entry = entriesForResource.get(key);
+  if (entry === undefined) {
+    var thenable = fetch(input);
+    thenable.then(
+      function(value) {
+        if (newResult.status === Pending) {
+          var resolvedResult = newResult;
+          resolvedResult.status = Resolved;
+          resolvedResult.value = value;
+        }
+      },
+      function(error) {
+        if (newResult.status === Pending) {
+          var rejectedResult = newResult;
+          rejectedResult.status = Rejected;
+          rejectedResult.value = error;
+        }
+      }
+    );
+    var newResult = {
+      status: Pending,
+      value: thenable,
+    };
+    var newEntry = lru.add(newResult, deleteEntry.bind(null, resource, key));
+    entriesForResource.set(key, newEntry);
+    return newResult;
+  } else {
+    return lru.access(entry);
+  }
+}
+
+function deleteEntry(resource, key) {
+  var entriesForResource = entries.get(resource);
+  if (entriesForResource !== undefined) {
+    entriesForResource.delete(key);
+    if (entriesForResource.size === 0) {
+      entries.delete(resource);
+    }
+  }
+}
+
+function unstable_createResource(fetch, maybeHashInput) {
+  var hashInput =
+    maybeHashInput !== undefined ? maybeHashInput : identityHashFn;
+
+  var resource = {
+    read: function(input) {
+      // react-cache currently doesn't rely on context, but it may in the
+      // future, so we read anyway to prevent access outside of render.
+      readContext(CacheContext);
+      var key = hashInput(input);
+      var result = accessResult(resource, fetch, input, key);
+      switch (result.status) {
+        case Pending: {
+          var suspender = result.value;
+          throw suspender;
+        }
+        case Resolved: {
+          var _value = result.value;
+          return _value;
+        }
+        case Rejected: {
+          var error = result.value;
+          throw error;
+        }
+        default:
+          // Should be unreachable
+          return undefined;
+      }
+    },
+    preload: function(input) {
+      // react-cache currently doesn't rely on context, but it may in the
+      // future, so we read anyway to prevent access outside of render.
+      readContext(CacheContext);
+      var key = hashInput(input);
+      accessResult(resource, fetch, input, key);
+    },
+  };
+  return resource;
+}
+
+function unstable_setGlobalCacheLimit(limit) {
+  lru.setLimit(limit);
+}
+
+export { unstable_createResource, unstable_setGlobalCacheLimit };


### PR DESCRIPTION
This PR adds support for a `suspense` option to the `useFetch` hook.

```js
import { useFetch } from 'use-fetch-hooks';

const Child = () => {
  const { data } = useFetch('https://example/api', { suspense: true });

  return <div>{data}</div>;
};

const Parent = () => (
  <React.Suspense fallback="Loading...">
    <Child />
  </React.Suspense>
);
```

A few notes:

- [react-cache](https://github.com/facebook/react/tree/master/packages/react-cache) (the default cache container maintained by the React team) is still unreleased, in major flux, and currently in a broken state, so I had to build an old version and check it into the repo for now 
- Using `suspense` and `lazy` together is not yet possible with `react-cache` (without some nastiness), so `useLazyFetch` has no `suspense` option yet

Other unrelated things:

- Disabled `react/prop-types` as we'll be adding TypeScript soon and won't have a need for prop types
- Added `import/resolver` setting so importing external dependencies (like `react`) don't throw lint errors
- Enabled source maps in `example` app
- Created `Container` component for example implementations

Closes #6 