### PR TITLE
cancel request if component unmounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7730,8 +7730,8 @@
     },
     "react": {
       "version": "16.9.0",
-      "resolved": "https://csdisco.jfrog.io/csdisco/api/npm/npm/react/-/react-16.9.0.tgz",
-      "integrity": "sha1-QLovmvE7waONddvy9DWaUYXE96o=",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -7741,8 +7741,8 @@
     },
     "react-dom": {
       "version": "16.9.0",
-      "resolved": "https://csdisco.jfrog.io/csdisco/api/npm/npm/react-dom/-/react-dom-16.9.0.tgz",
-      "integrity": "sha1-XmVSel4m8irjcBExvMyu6fsNOWI=",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",

--- a/src/useBaseFetch.test.ts
+++ b/src/useBaseFetch.test.ts
@@ -9,10 +9,19 @@ interface AxiosMock extends AxiosStatic {
 
 jest.mock('axios');
 const mockedAxios = axios as AxiosMock;
+const { CancelToken } = axios;
+
+beforeEach(() => {
+  CancelToken.source = jest.fn().mockImplementation(() => ({
+    token: 'abc',
+  }));
+});
 
 test('loading is true before fetch resolves/rejects', () => {
+  const source = CancelToken.source();
   const { result } = renderHook(() =>
     useBaseFetch({
+      cancelToken: source.token,
       method: 'get',
       url: '/test',
     })
@@ -33,9 +42,11 @@ test('loading is true before fetch resolves/rejects', () => {
 
 test('data is truthy when fetch resolves', async () => {
   mockedAxios.mockResolvedValue({ data: {} });
+  const source = CancelToken.source();
 
   const { result, waitForNextUpdate } = renderHook(() =>
     useBaseFetch({
+      cancelToken: source.token,
       method: 'get',
       url: '/test',
     })
@@ -58,9 +69,11 @@ test('data is truthy when fetch resolves', async () => {
 
 test('error is truthy when fetch rejects', async () => {
   mockedAxios.mockRejectedValue(new Error('Error'));
+  const source = CancelToken.source();
 
   const { result, waitForNextUpdate } = renderHook(() =>
     useBaseFetch({
+      cancelToken: source.token,
       method: 'get',
       url: '/test',
     })

--- a/src/useBaseFetch.ts
+++ b/src/useBaseFetch.ts
@@ -15,7 +15,6 @@ export default <Data>(config: AxiosRequestConfig): BaseFetch<Data> => {
   const [error, setError] = useState<Error | null>(null);
   const isMounted = useRef(true);
 
-  const { current } = isMounted;
   const { CancelToken } = axios;
   const source = CancelToken.source();
 
@@ -38,13 +37,13 @@ export default <Data>(config: AxiosRequestConfig): BaseFetch<Data> => {
       const res = (await axios(configWithCancelToken(config))) as AxiosResponse<
         Data
       >;
-      if (current) {
+      if (isMounted.current) {
         setData(res.data);
         setLoading(false);
         setError(null);
       }
     } catch (e) {
-      if (current) {
+      if (isMounted.current) {
         setError(e);
         setLoading(false);
       }

--- a/src/useBaseFetch.ts
+++ b/src/useBaseFetch.ts
@@ -18,7 +18,7 @@ export default <Data>(config: AxiosRequestConfig): BaseFetch<Data> => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
 
-  const configWithCancelToken = rawConfig => {
+  const getConfig = rawConfig => {
     if (typeof rawConfig === 'string') {
       return {
         url: rawConfig,
@@ -34,9 +34,7 @@ export default <Data>(config: AxiosRequestConfig): BaseFetch<Data> => {
   const getData = async () => {
     try {
       setLoading(true);
-      const res = (await axios(configWithCancelToken(config))) as AxiosResponse<
-        Data
-      >;
+      const res = (await axios(getConfig(config))) as AxiosResponse<Data>;
       if (isMounted.current) {
         setData(res.data);
         setLoading(false);


### PR DESCRIPTION
- Add support to cancel network request if component unmounts during request based on these [docs](https://github.com/axios/axios#cancellation)
- Add config check in `useBaseFetch` to add `cancelToken` based on if user passed in only the url (`useFetch('https://example/api')` or a request config object (`useFetch({ url: 'https://example/api', method: 'get' })` 
- Update tests to mock `cancelToken`

Closes #7 