### PR TITLE
Add hook overload type signatures to match axios API

### DIFF
--- a/example/src/useFetch/Basic.tsx
+++ b/example/src/useFetch/Basic.tsx
@@ -9,9 +9,9 @@ interface Data {
 }
 
 export default () => {
-  const { data, error, loading } = useFetch<Data>({
-    url: 'https://reqres.in/api/things/1',
-  });
+  const { data, error, loading } = useFetch<Data>(
+    'https://reqres.in/api/things/1'
+  );
 
   if (loading) {
     return <div>Loading...</div>;

--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -2,12 +2,28 @@ import { useEffect } from 'react';
 import { AxiosRequestConfig } from 'axios';
 import useBaseFetch, { RequestState } from './useBaseFetch';
 
-export default <Data>(config: AxiosRequestConfig): RequestState<Data> => {
-  const [getData, { data, error, loading }] = useBaseFetch<Data>(config);
+function useFetch<Data>(url: string): RequestState<Data>;
+function useFetch<Data>(config: AxiosRequestConfig): RequestState<Data>;
+function useFetch<Data>(
+  url: string,
+  config: AxiosRequestConfig
+): RequestState<Data>;
+function useFetch<Data>(
+  param1: string | AxiosRequestConfig,
+  param2?: AxiosRequestConfig
+): RequestState<Data> {
+  const [getData, { data, error, loading }] =
+    typeof param1 === 'string'
+      ? useBaseFetch<Data>(param1, param2 || {})
+      : useBaseFetch<Data>(param1);
+
+  const url = typeof param1 === 'string' ? param1 : param1.url;
 
   useEffect(() => {
     getData();
-  }, [config.url]);
+  }, [url]);
 
   return { data, error, loading };
-};
+}
+
+export default useFetch;

--- a/src/useLazyFetch.ts
+++ b/src/useLazyFetch.ts
@@ -1,8 +1,22 @@
 import { AxiosRequestConfig } from 'axios';
 import useBaseFetch, { BaseFetch } from './useBaseFetch';
 
-export default <Data>(config: AxiosRequestConfig): BaseFetch<Data> => {
-  const [getData, { data, error, loading }] = useBaseFetch<Data>(config);
+function useLazyFetch<Data>(url: string): BaseFetch<Data>;
+function useLazyFetch<Data>(config: AxiosRequestConfig): BaseFetch<Data>;
+function useLazyFetch<Data>(
+  url: string,
+  config: AxiosRequestConfig
+): BaseFetch<Data>;
+function useLazyFetch<Data>(
+  param1: string | AxiosRequestConfig,
+  param2?: AxiosRequestConfig
+): BaseFetch<Data> {
+  const [getData, { data, error, loading }] =
+    typeof param1 === 'string'
+      ? useBaseFetch<Data>(param1, param2 || {})
+      : useBaseFetch<Data>(param1);
 
   return [getData, { data, error, loading }];
-};
+}
+
+export default useLazyFetch;


### PR DESCRIPTION
This adds the necessary function overload type signatures to allow consumers to use the hooks in the same ways that calling `axios` allows.

#### With only URL

```js
const { data, error, loading } = useFetch<Data>('https://reqres.in/api/things/1');
```

#### With only config hash

```js
const { data, error, loading } = useFetch<Data>({
  url: 'https://reqres.in/api/things/1'
});
```

#### With URL string and config hash

```js
const { data, error, loading } = useFetch<Data>('https://reqres.in/api/things/1', {
  method: 'POST'
});
```

All of these signatures work and are fully typesafe.